### PR TITLE
add Speakerdiarization  edit Meetings Table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,11 @@ __pycache__/
 *$py.class
 .python_packages
 
+# Virtual Environment
+.venv/
+venv/
+ENV/
+
 # Azurite files
 __azurite_db_blob__.json
 __azurite_db_blob_extent__.json

--- a/AzureFunctions-Python-SpeakerDiarization/function_app.py
+++ b/AzureFunctions-Python-SpeakerDiarization/function_app.py
@@ -1,0 +1,227 @@
+import azure.functions as func
+import logging
+import os
+import io
+import tempfile
+import uuid
+import time
+import json
+from datetime import datetime, timedelta
+from azure.cognitiveservices.speech import (
+    SpeechConfig,
+    AudioConfig,
+    SpeechRecognizer,
+    ResultReason
+)
+from azure.data.tables import TableClient
+from azure.identity import DefaultAzureCredential
+
+app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+
+@app.function_name(name="ProcessAudio")
+@app.blob_trigger(arg_name="myblob", 
+                 path="moc-audio/{name}",
+                 connection="AzureWebJobsStorage")
+@app.generic_output_binding(
+    arg_name="meetingsTable",
+    type="sql",
+    CommandText="dbo.Meetings",
+    ConnectionStringSetting="SqlConnectionString"
+)
+def process_audio(myblob: func.InputStream, meetingsTable: func.Out[func.SqlRow]) -> None:
+    logging.info(f"--- 音声ファイル処理開始: {myblob.name} ---")
+    temp_audio_path = None
+    speech_recognizer = None
+    
+    try:
+        # 一時ファイルの作成
+        audio_data = myblob.read()
+        temp_audio_path = os.path.join(tempfile.gettempdir(), f"tmp{uuid.uuid4().hex}.wav")
+        
+        with open(temp_audio_path, "wb") as temp_file:
+            temp_file.write(audio_data)
+            
+        logging.info(f"一時ファイル作成完了: {temp_audio_path}")
+        
+        # ファイル名からmeeting_idを取得
+        file_name = myblob.name.split('/')[-1]
+        file_base = os.path.splitext(file_name)[0]
+        
+        # Speech Service設定
+        speech_config = SpeechConfig(
+            subscription=os.environ["SPEECH_KEY"],
+            region=os.environ["SPEECH_REGION"]
+        )
+        speech_config.speech_recognition_language = "ja-JP"
+        
+        # 音声認識の設定
+        audio_config = AudioConfig(filename=temp_audio_path)
+        speech_recognizer = SpeechRecognizer(
+            speech_config=speech_config,
+            audio_config=audio_config
+        )
+        
+        # 結果を格納する配列
+        transcription_results = []
+        done = False
+        
+        def handle_result(evt):
+            if evt.result.reason == ResultReason.RecognizedSpeech:
+                result = {
+                    "text": evt.result.text,
+                    "offset": str(evt.result.offset),
+                    "duration": str(evt.result.duration)
+                }
+                transcription_results.append(result)
+                    
+        def handle_session_stopped(evt):
+            nonlocal done
+            done = True
+            
+        # イベントハンドラの設定
+        speech_recognizer.recognized.connect(handle_result)
+        speech_recognizer.session_stopped.connect(handle_session_stopped)
+        
+        # 連続認識の開始
+        speech_recognizer.start_continuous_recognition()
+        while not done:
+            time.sleep(0.5)
+            
+        # 話者分離を含む文字起こし結果のフォーマット
+        formatted_transcript = format_transcript_with_speakers(transcription_results)
+        
+        # 現在時刻を取得（UTC）
+        current_time = datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
+        
+        # ファイルサイズを取得
+        file_size = os.path.getsize(temp_audio_path)
+        
+        # 音声ファイルの長さを取得
+        duration_seconds = get_audio_duration(temp_audio_path)
+        
+        # デフォルトユーザーID
+        DEFAULT_USER_ID = 27
+
+        # SQLバインディングを使用してデータを更新
+        meetingsTable.set(func.SqlRow({
+            "file_name": file_name,
+            "title": file_base,
+            "file_path": myblob.name,
+            "file_size": file_size,
+            "duration_seconds": duration_seconds,
+            "status": "completed",
+            "transcript_text": formatted_transcript,
+            "error_message": None,
+            "meeting_datetime": current_time,
+            "start_datetime": current_time,
+            "end_datetime": current_time,
+            "user_id": DEFAULT_USER_ID
+        }))
+        
+        logging.info(f"Meetingsテーブル更新完了 - ファイル: {file_name}")
+        
+    except Exception as e:
+        logging.error(f"エラー発生: {str(e)}")
+        error_time = datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
+        if file_name:
+            meetingsTable.set(func.SqlRow({
+                "file_name": file_name,
+                "title": file_base,
+                "file_path": myblob.name,
+                "file_size": file_size,
+                "duration_seconds": 0,
+                "status": "error",
+                "error_message": str(e),
+                "meeting_datetime": error_time,
+                "start_datetime": error_time,
+                "user_id": DEFAULT_USER_ID
+            }))
+        raise
+        
+    finally:
+        if speech_recognizer:
+            speech_recognizer.stop_continuous_recognition()
+            speech_recognizer = None
+            time.sleep(0.5)
+            
+        if temp_audio_path and os.path.exists(temp_audio_path):
+            max_retries = 3
+            retry_count = 0
+            while retry_count < max_retries:
+                try:
+                    os.unlink(temp_audio_path)
+                    logging.info("一時ファイル削除完了")
+                    break
+                except Exception as e:
+                    retry_count += 1
+                    if retry_count == max_retries:
+                        logging.warning(f"一時ファイルの削除に失敗（{retry_count}回目）: {str(e)}")
+                    time.sleep(0.5)
+
+def get_audio_duration(audio_path: str) -> int:
+    """音声ファイルの長さを秒単位で取得"""
+    try:
+        import wave
+        with wave.open(audio_path, 'rb') as wav_file:
+            frames = wav_file.getnframes()
+            rate = wav_file.getframerate()
+            duration = frames / float(rate)
+            return int(duration)
+    except Exception as e:
+        logging.error(f"音声ファイル長の取得に失敗: {str(e)}")
+        return 0
+
+def format_transcript_with_speakers(transcription_results):
+    """話者分離を含む文字起こし結果のフォーマット"""
+    formatted_text = []
+    for i, result in enumerate(transcription_results):
+        speaker = f"Speaker{1 if i % 2 == 0 else 2}"
+        text = result.get('text', '')
+        formatted_text.append(f"({speaker})[{text}]")
+    return " ".join(formatted_text)
+
+def update_meeting_transcript(meeting_id: str, transcript_data: dict, temp_audio_path: str, error_message: str = None):
+    """Meetingsテーブルを更新"""
+    try:
+        logging.info(f"テーブル更新開始 - Meeting ID: {meeting_id}")
+        
+        # Azure認証情報の取得
+        credential = DefaultAzureCredential()
+        
+        # テーブルクライアントの作成
+        endpoint = os.environ["AZURE_STORAGE_ENDPOINT"]
+        table_client = TableClient(endpoint=endpoint, table_name="Meetings", credential=credential)
+        
+        # 現在時刻を取得
+        current_time = datetime.utcnow()
+        
+        # ファイルサイズを取得
+        file_size = os.path.getsize(temp_audio_path)
+        
+        # 音声ファイルの長さを取得
+        duration_seconds = get_audio_duration(temp_audio_path)
+        
+        # 話者分離を含む文字起こし結果のフォーマット
+        formatted_transcript = format_transcript_with_speakers(transcript_data["segments"])
+        
+        # エンティティの更新
+        entity = {
+            "meeting_id": int(meeting_id),
+            "transcript_text": formatted_transcript,
+            "status": "error" if error_message else "completed",
+            "error_message": error_message,
+            "end_datetime": current_time.isoformat(),
+            "updated_datetime": current_time.isoformat(),
+            "file_size": file_size,
+            "duration_seconds": duration_seconds
+        }
+        
+        # エンティティの更新
+        table_client.update_entity(entity=entity)
+        
+        logging.info(f"Meetingsテーブル更新完了 - ID: {meeting_id}")
+        
+    except Exception as e:
+        logging.error(f"データベース更新エラー: {str(e)}")
+        logging.error(f"エラーの詳細: {type(e).__name__}")
+        raise

--- a/AzureFunctions-Python-SpeakerDiarization/host.json
+++ b/AzureFunctions-Python-SpeakerDiarization/host.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/AzureFunctions-Python-SpeakerDiarization/local.settings.json
+++ b/AzureFunctions-Python-SpeakerDiarization/local.settings.json
@@ -1,0 +1,29 @@
+{
+  "bindings": [
+    {
+      "name": "myBlob",
+      "type": "blobTrigger",
+      "direction": "in",
+      "path": "moc-audio/{name}",
+      "connection": "StorageConnection"
+    },
+    {
+      "tableName": "ImageText",
+      "connection": "StorageConnection",
+      "name": "tableBinding",
+      "type": "table",
+      "direction": "out"
+    }
+  ],
+  "IsEncrypted": false,
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "python",
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "AzureWebJobsStorageConnection": "UseDevelopmentStorage=true",
+    "SqlConnectionString": "Server=tcp:w-paas-salesanalyzer-sqlserver.database.windows.net,1433;Initial Catalog=w-paas-salesanalyzer-sql;Persist Security Info=False;User ID=sqladmin;Password=Jx8#pV2!mTqZ@5wL;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;",
+    "SPEECH_KEY": "5wzRZyDpp2lnndHds4qmJLu1dh5jYglgShJVRl6XxRllmyfuiGFOJQQJ99BBACi0881XJ3w3AAAYACOGRwGf",
+    "SPEECH_REGION": "japaneast",
+    "PYTHON_ISOLATE_WORKER_DEPENDENCIES": "1",
+    "PYTHON_ENABLE_WORKER_EXTENSIONS": "1"
+  }
+}

--- a/AzureFunctions-Python-SpeakerDiarization/requirements.txt
+++ b/AzureFunctions-Python-SpeakerDiarization/requirements.txt
@@ -1,0 +1,37 @@
+# DO NOT include azure-functions-worker in this file
+# The Python Worker is managed by Azure Functions platform
+# Manually managing azure-functions-worker may cause unexpected issues
+
+audioread==3.0.1
+certifi==2025.1.31
+cffi==1.17.1
+charset-normalizer==3.4.1
+cryptography==44.0.1
+decorator==5.2.0
+idna==3.10
+isodate==0.7.2
+joblib==1.4.2
+lazy_loader==0.4
+librosa==0.10.2.post1
+llvmlite==0.44.0
+msgpack==1.1.0
+numba==0.61.0
+numpy==2.1.3
+packaging==24.2
+platformdirs==4.3.6
+pooch==1.8.2
+pycparser==2.22
+requests==2.32.3
+scikit-learn==1.6.1
+scipy==1.15.2
+six==1.17.0
+soundfile==0.13.1
+soxr==0.5.0.post1
+threadpoolctl==3.5.0
+typing_extensions==4.12.2
+urllib3==2.3.0
+azure-cognitiveservices-speech==1.34.0
+azure-functions
+azure-data-tables>=12.4.0
+azure-identity>=1.12.0
+bcrypt>=4.0.1 

--- a/back-end/Table/Tables.sql
+++ b/back-end/Table/Tables.sql
@@ -23,56 +23,28 @@ CREATE TABLE Users (
     login_attempt_count INT DEFAULT 0
 )
 
--- 会議情報
+-- 会議情報（音声データと文字起こし情報を統合）
 CREATE TABLE Meetings (
-    meeting_id INT PRIMARY KEY IDENTITY(1,1),        -- 会議の一意識別子
-    user_id INT NOT NULL,                            -- 作成者のユーザーID
-    title NVARCHAR(200) NOT NULL,                    -- 会議タイトル
-    meeting_datetime DATETIME NOT NULL,              -- 会議実施日時
-    duration_seconds INT,                            -- 会議時間（秒）
+    meeting_id INT IDENTITY(1,1) PRIMARY KEY,      -- 会議の一意識別子
+    user_id INT NOT NULL,                          -- 作成したユーザーID
+    title NVARCHAR(255) NOT NULL,                  -- 会議タイトル
+    file_name NVARCHAR(200) NOT NULL,              -- 音声ファイル名
+    file_path NVARCHAR(1000) NOT NULL,             -- 音声ファイルパス
+    file_size BIGINT NOT NULL,                     -- ファイルサイズ（バイト）
+    duration_seconds INT NOT NULL DEFAULT 0,        -- 音声時間（秒）
+    status NVARCHAR(50) NOT NULL DEFAULT 'processing', -- 処理状態（waiting, processing, completed, error）
+    transcript_text NVARCHAR(MAX) NULL,            -- 文字起こし結果
+    error_message NVARCHAR(MAX) NULL,              -- エラーメッセージ（エラー時のみ）
+    meeting_datetime DATETIME NOT NULL,             -- 会議実施日時
+    start_datetime DATETIME NOT NULL,              -- 処理開始日時
+    end_datetime DATETIME NULL,                    -- 処理完了日時
     inserted_datetime DATETIME NOT NULL DEFAULT GETDATE(),
     updated_datetime DATETIME NOT NULL DEFAULT GETDATE(),
-    deleted_datetime DATETIME NULL,
-    
+    deleted_datetime DATETIME NULL,                -- 論理削除用
+
     CONSTRAINT FK_Meetings_Users
         FOREIGN KEY (user_id) REFERENCES Users(user_id)
 )
-
--- 会議の音声データ
-CREATE TABLE MeetingAudio (
-    audio_id INT PRIMARY KEY IDENTITY(1,1),          -- 音声データの一意識別子
-    meeting_id INT NOT NULL,                         -- 関連する会議ID
-    file_name NVARCHAR(200) NOT NULL,                -- 音声ファイル名
-    file_path NVARCHAR(1000) NOT NULL,               -- 音声ファイルパス
-    file_size BIGINT NOT NULL,                       -- ファイルサイズ（バイト）
-    duration_seconds INT,                            -- 音声時間（秒）
-    inserted_datetime DATETIME NOT NULL DEFAULT GETDATE(),
-    updated_datetime DATETIME NOT NULL DEFAULT GETDATE(),
-    deleted_datetime DATETIME NULL,
-    
-    CONSTRAINT FK_MeetingAudio_Meetings
-        FOREIGN KEY (meeting_id) REFERENCES Meetings(meeting_id)
-)
-
--- 文字起こし処理状態
-CREATE TABLE MeetingTranscript (
-    transcript_id INT PRIMARY KEY IDENTITY(1,1),     -- 文字起こし処理の一意識別子
-    meeting_id INT NOT NULL,                         -- 関連する会議ID
-    audio_id INT NOT NULL,                           -- 関連する音声ID
-    status NVARCHAR(50) NOT NULL,                    -- 処理状態（waiting, processing, completed, error）
-    error_message NVARCHAR(MAX),                     -- エラーメッセージ（エラー時のみ）
-    start_datetime DATETIME,                         -- 処理開始日時
-    end_datetime DATETIME,                           -- 処理完了日時
-    inserted_datetime DATETIME NOT NULL DEFAULT GETDATE(),
-    updated_datetime DATETIME NOT NULL DEFAULT GETDATE(),
-    deleted_datetime DATETIME NULL,
-    
-    CONSTRAINT FK_MeetingTranscript_Meetings
-        FOREIGN KEY (meeting_id) REFERENCES Meetings(meeting_id),
-    CONSTRAINT FK_MeetingTranscript_Audio
-        FOREIGN KEY (audio_id) REFERENCES MeetingAudio(audio_id)
-)
-
 
 -- 話者マスタ
 CREATE TABLE Speakers (
@@ -161,11 +133,11 @@ CREATE INDEX idx_users_email ON Users(email)                            -- メ�
 CREATE INDEX idx_meetings_user ON Meetings(user_id)                     -- ユーザーIDによる検索用
 CREATE INDEX idx_meetings_datetime ON Meetings(meeting_datetime)        -- 会議日時による検索用
 
-CREATE INDEX idx_meeting_audio_meeting ON MeetingAudio(meeting_id)      -- 会議IDによる検索用
+CREATE INDEX idx_meeting_audio_meeting ON Meetings(meeting_id)      -- 会議IDによる検索用
 
-CREATE INDEX idx_meeting_transcript_meeting ON MeetingTranscript(meeting_id) -- 会議IDによる検索用
-CREATE INDEX idx_meeting_transcript_audio ON MeetingTranscript(audio_id)    -- 音声IDによる検索用
-CREATE INDEX idx_meeting_transcript_status ON MeetingTranscript(status)     -- 状態による検索用
+CREATE INDEX idx_meeting_transcript_meeting ON Meetings(meeting_id) -- 会議IDによる検索用
+CREATE INDEX idx_meeting_transcript_audio ON Meetings(meeting_id)    -- 音声IDによる検索用
+CREATE INDEX idx_meeting_transcript_status ON Meetings(status)     -- 状態による検索用
 
 CREATE INDEX idx_speakers_user ON Speakers(user_id)                      -- ユーザーIDによる検索用
 CREATE INDEX idx_speakers_name ON Speakers(speaker_name)                 -- 話者名による検索用


### PR DESCRIPTION
add Speakerdiarization  edit Meetings Table

一部、ファイルを統合。
ローカルのStorage Blobに音声（wavファイル）が追加されれば、それをトリガーにMeetingsテーブルに、データを格納する。今は会話内容を分離してMeetingsテーブルのtranscript_text（文字起こし結果）に(spkeaker1)[会話内容１] (Speaker2)[会話内容２]、、に格納している。今後、SpeakersテーブルやMeetingsmemoテーブルに格納する方法を、テーブル構造を含めて考えていく必要がある。