### PR TITLE
テスト用ナビゲーションの追加と認証リダイレクトの一時無効化

### DIFF
--- a/next-app/middleware.ts
+++ b/next-app/middleware.ts
@@ -41,7 +41,9 @@ export function middleware(request: NextRequest) {
     return NextResponse.redirect(new URL('/dashboard', request.url))
   }
 
+  // ===== ここから一時的にコメントアウト（テスト用 - 後で元に戻す）=====
   // 認証済みのユーザーがログインページや登録ページへアクセスした場合
+  /*
   if (publicRoutes.includes(pathname) && isAuthenticated) {
     if (pathname === '/') {
       console.log(`Authenticated user on login page, redirecting to appropriate dashboard`)
@@ -52,6 +54,8 @@ export function middleware(request: NextRequest) {
       }
     }
   }
+  */
+  // ===== ここまで一時的にコメントアウト（テスト用 - 後で元に戻す）=====
 
   return NextResponse.next()
 }

--- a/next-app/src/app/page.tsx
+++ b/next-app/src/app/page.tsx
@@ -1,14 +1,24 @@
 import { Suspense } from 'react'
 import dynamic from 'next/dynamic'
+import Link from 'next/link'
+import { Card } from '@/components/ui/card'
 
 // クライアントコンポーネントを動的にインポート
 const LoginForm = dynamic(() => import('@/components/auth/LoginForm'), {
   ssr: false, // サーバーサイドレンダリングを無効化
 })
 
+// テスト用ナビゲーションコンポーネント（要削除）
+const TestNavigation = dynamic(() => import('@/components/TestNavigation'), {
+  ssr: false
+})
+
 export default function LoginPage() {
   return (
-    <div className="min-h-screen bg-[#1F1F1F] flex items-center justify-center p-4">
+    <div className="min-h-screen bg-[#1F1F1F] flex items-center justify-center p-4 relative">
+      {/* テスト用ナビゲーション（要削除） */}
+      <TestNavigation />
+
       <div className="w-full max-w-sm space-y-6">
         <h1 className="text-2xl font-bold text-center text-white">ログイン</h1>
         <Suspense fallback={<div className="text-white text-center">読み込み中...</div>}>

--- a/next-app/src/components/TestNavigation.tsx
+++ b/next-app/src/components/TestNavigation.tsx
@@ -1,0 +1,115 @@
+"use client"
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { Card } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import Cookies from 'js-cookie'
+
+/**
+ * テスト用ナビゲーションコンポーネント
+ * 固定のuser_id=27を使用した認証をシミュレートする
+ * 
+ * 【注意】このコンポーネントは開発/テスト用であり、リリース前に削除すること
+ */
+export default function TestNavigation() {
+  const router = useRouter()
+  const [statusMessage, setStatusMessage] = useState('')
+
+  // テスト用の認証データ（要削除）- useAuthと同じ形式に合わせる
+  const testUser = {
+    user_id: 27, // テスト用固定ユーザーID（要削除）
+    email: "test@example.com",
+    user_name: "テストユーザー",
+    is_manager: true,
+    role: "manager"
+  }
+
+  // 本番と同様の形式のトークン（テスト用）
+  const testToken = "test-token-for-development-" + Date.now()
+
+  // アプリ内の全ての画面へのナビゲーションリンク
+  const navLinks = [
+    { name: 'ダッシュボード', path: '/dashboard', needsAuth: true },
+    { name: 'マネージャーダッシュボード', path: '/manager-dashboard', needsAuth: true },
+    { name: '新規商談', path: '/newmeeting', needsAuth: true },
+    { name: '録音', path: '/recording', needsAuth: true },
+    { name: '商談検索', path: '/search', needsAuth: true },
+    { name: 'フィードバック', path: '/feedback', needsAuth: true },
+    { name: '新規登録', path: '/register', needsAuth: false },
+  ]
+
+  // テスト用の認証情報をセットアップして指定ページに遷移する関数（要削除）
+  const navigateWithAuth = (path: string) => {
+    try {
+      // 認証データをuseAuthフックと同じ形式で設定
+      const userData = JSON.stringify(testUser)
+      
+      // Cookie有効期限（7日間 - useAuthと同じ）
+      const COOKIE_EXPIRY = 7
+      
+      // ローカルストレージに認証情報を保存
+      localStorage.setItem('user', userData)
+      localStorage.setItem('token', testToken)
+      
+      // Cookieにも保存（ミドルウェア用）- js-cookieを使用してuseAuthと同じ方法
+      Cookies.set('user', userData, { expires: COOKIE_EXPIRY })
+      Cookies.set('authToken', testToken, { expires: COOKIE_EXPIRY })
+      
+      // ステータスメッセージ更新
+      setStatusMessage(`認証情報をセット (ID:${testUser.user_id})...`)
+      
+      // 遷移処理
+      setTimeout(() => {
+        // window.location.hrefを使用して完全なページリロードで遷移（ミドルウェア確実に動作させる）
+        window.location.href = path
+      }, 500)
+    } catch (error) {
+      setStatusMessage('エラーが発生しました')
+      console.error('テストナビゲーションエラー:', error)
+    }
+  }
+
+  return (
+    <div className="absolute top-4 left-4 z-50">
+      <Card className="p-3 bg-yellow-500/20 border border-yellow-500">
+        <div className="text-xs font-bold text-yellow-400 mb-2">
+          テスト用ナビゲーション（要削除）<br/>
+          <span className="text-[10px] text-yellow-300">※固定user_id=27使用</span>
+        </div>
+        <div className="text-[10px] bg-yellow-800/30 text-yellow-300 p-1 rounded mb-2">
+          注意: ログイン画面に戻りたい場合は、ダッシュボード画面からログアウトを行う
+        </div>
+        {statusMessage && (
+          <div className="text-[10px] bg-green-800/30 text-green-400 p-1 rounded mb-2">
+            {statusMessage}
+          </div>
+        )}
+        <div className="flex flex-col gap-1">
+          {navLinks.map((link) => 
+            link.needsAuth ? (
+              <Button 
+                key={link.path}
+                variant="link" 
+                size="sm"
+                className="text-xs text-white hover:text-yellow-400 transition-colors p-0 h-auto justify-start font-normal"
+                onClick={() => navigateWithAuth(link.path)}
+              >
+                → {link.name}
+              </Button>
+            ) : (
+              <Link 
+                key={link.path} 
+                href={link.path}
+                className="text-xs text-white hover:text-yellow-400 transition-colors"
+              >
+                → {link.name}
+              </Link>
+            )
+          )}
+        </div>
+      </Card>
+    </div>
+  )
+} 


### PR DESCRIPTION
- テスト用ナビゲーションコンポーネントを追加（/components/TestNavigation.tsx）
- 固定ユーザーID（user_id=27）を使用した認証処理の実装
- ミドルウェアのログイン画面自動リダイレクト処理を一時的にコメントアウト
- すべての画面に簡単にアクセスできるようにテスト環境を改善
- 注意：このコンポーネントは開発/テスト用であり、リリース前に削除すること