### PR TITLE
ユーザー情報表示機能の改善

### DIFF
--- a/AzureFunctions-Python-api/function_app.py
+++ b/AzureFunctions-Python-api/function_app.py
@@ -8,7 +8,7 @@ import logging
 from azure.functions import AuthLevel, FunctionApp
 
 # モジュール構造からのインポート
-from src.auth import login, register
+from src.auth import login, register, get_user_by_id
 from src.meetings import get_meetings, get_members_meetings, save_meeting, save_basic_info
 
 # Azure Functions アプリケーションの初期化
@@ -41,6 +41,18 @@ def register_test(req: func.HttpRequest, users: func.Out[func.SqlRow]) -> func.H
 )
 def login_func(req: func.HttpRequest, usersQuery: func.SqlRowList) -> func.HttpResponse:
     return login(req, usersQuery)
+
+# ユーザー情報取得エンドポイント
+@app.function_name(name="GetUserById")
+@app.route(route="users/{user_id}", methods=["GET", "OPTIONS"])
+@app.generic_input_binding(
+    arg_name="usersQuery", 
+    type="sql",
+    CommandText="SELECT user_id, user_name, email, is_manager, manager_name, is_active, account_status FROM dbo.Users",
+    ConnectionStringSetting="SqlConnectionString"
+)
+def get_user_by_id_func(req: func.HttpRequest, usersQuery: func.SqlRowList) -> func.HttpResponse:
+    return get_user_by_id(req, usersQuery)
 
 #
 # 会議関連のエンドポイント

--- a/AzureFunctions-Python-api/src/auth/__init__.py
+++ b/AzureFunctions-Python-api/src/auth/__init__.py
@@ -1,3 +1,3 @@
-from .auth_handlers import login, register, check_manager
+from .auth_handlers import login, register, check_manager, get_user_by_id
 
-__all__ = ['login', 'register', 'check_manager'] 
+__all__ = ['login', 'register', 'check_manager', 'get_user_by_id'] 

--- a/AzureFunctions-Python-api/src/meetings/meeting_handlers.py
+++ b/AzureFunctions-Python-api/src/meetings/meeting_handlers.py
@@ -73,8 +73,6 @@ def get_members_meetings(req: func.HttpRequest, users_query: func.SqlRowList, me
         manager_id = req.params.get('manager_id')
         show_all = req.params.get('show_all', '').lower() == 'true'
         
-        logging.info(f"[DEBUG] Received manager_id: {manager_id}, show_all: {show_all}")
-        
         if not manager_id:
             return create_error_response("manager_id is required", 400)
         
@@ -84,8 +82,6 @@ def get_members_meetings(req: func.HttpRequest, users_query: func.SqlRowList, me
             if str(user.get("user_id")) == manager_id:
                 manager_name = user.get("user_name")
                 break
-        
-        logging.info(f"[DEBUG] Found manager_name: {manager_name}")
         
         if not manager_name:
             return create_error_response("Manager not found", 404)
@@ -97,15 +93,6 @@ def get_members_meetings(req: func.HttpRequest, users_query: func.SqlRowList, me
             if show_all or user_dict.get("manager_name") == manager_name:
                 user_id = str(user_dict.get("user_id"))
                 team_member_ids.append(user_id)
-                logging.info(f"[DEBUG] Found team member - user_id: {user_id}, user_name: {user_dict.get('user_name')}, manager_name: {user_dict.get('manager_name')}")
-        
-        logging.info(f"[DEBUG] Team member IDs: {team_member_ids}")
-        
-        # すべてのユーザーのmanager_name情報をログに出力
-        logging.info("[DEBUG] All users manager_name info:")
-        for user in users_query:
-            user_dict = dict(user)
-            logging.info(f"[DEBUG] user_id: {user_dict.get('user_id')}, user_name: {user_dict.get('user_name')}, manager_name: {user_dict.get('manager_name')}")
         
         # チームメンバーのミーティングを取得
         meetings = []
@@ -120,16 +107,12 @@ def get_members_meetings(req: func.HttpRequest, users_query: func.SqlRowList, me
                     meeting = Meeting.from_dict(row_dict)
                     meetings.append(meeting.to_dict())
                     meeting_count += 1
-                    logging.info(f"[DEBUG] Found meeting for team member - meeting_id: {row_dict.get('meeting_id')}, user_id: {row_user_id}, title: {row_dict.get('title')}")
             except Exception as row_error:
                 logging.error(f"Error processing row: {str(row_error)}")
-        
-        logging.info(f"[DEBUG] Total meetings found: {meeting_count}")
         
         if meetings:
             return create_json_response({"meetings": meetings})
         else:
-            logging.info(f"[DEBUG] No meetings found for team members with IDs: {team_member_ids}")
             return create_json_response({"message": "No meetings found for the team members"})
     except Exception as e:
         logging.error(f"Error retrieving team meetings: {str(e)}")

--- a/next-app/src/app/dashboard/page.tsx
+++ b/next-app/src/app/dashboard/page.tsx
@@ -9,11 +9,13 @@ import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { useAuth } from "@/hooks/useAuth"
+import { useUser } from "@/hooks/useUser"
 import { useMeetings } from "@/hooks/useMeetings"
 import ProtectedRoute from "@/components/auth/ProtectedRoute"
 
 export default function Dashboard() {
   const { user, logout, isManager } = useAuth()
+  const { userInfo, loading: userLoading } = useUser()
   const { meetings, loading, error } = useMeetings()
   const router = useRouter()
   
@@ -74,7 +76,7 @@ export default function Dashboard() {
           {/* ユーザー名とログアウトボタン */}
           <div className="flex justify-between items-center mb-4">
             <div className="text-xl font-medium">
-              {user?.user_name || "ユーザー"} 様
+              {userInfo?.user_name || user?.user_name || "ユーザー"} 様
             </div>
             <Button 
               variant="outline" 

--- a/next-app/src/app/manager-dashboard/page.tsx
+++ b/next-app/src/app/manager-dashboard/page.tsx
@@ -7,6 +7,7 @@ import { Search, PlusCircle, LogOut, User } from "lucide-react"
 import Link from "next/link"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { useAuth } from "@/hooks/useAuth"
+import { useUser } from "@/hooks/useUser"
 import { useMembersMeetings } from "@/hooks/useMembersMeetings"
 import React, { useState, useEffect } from "react"
 import ProtectedRoute from "@/components/auth/ProtectedRoute"
@@ -14,6 +15,7 @@ import ProtectedRoute from "@/components/auth/ProtectedRoute"
 export default function ManagerDashboard() {
   // useAuthフックを使用してユーザー情報とログアウト関数を取得
   const { user, logout } = useAuth();
+  const { userInfo, loading: userLoading } = useUser();
   const { meetings, loading, error } = useMembersMeetings();
   
   const comments = [
@@ -76,7 +78,7 @@ export default function ManagerDashboard() {
           {/* ユーザー名とログアウトボタン */}
           <div className="flex justify-between items-center mb-4">
             <div className="text-xl font-medium">
-              {user?.user_name ? `${user.user_name} MGR` : 'MGR'}
+              {userInfo ? `${userInfo.user_name} MGR` : (user?.user_name ? `${user.user_name} MGR` : 'MGR')}
             </div>
             <Button 
               variant="outline" 

--- a/next-app/src/hooks/useUser.tsx
+++ b/next-app/src/hooks/useUser.tsx
@@ -1,0 +1,74 @@
+"use client"
+
+import { useState, useEffect, useCallback } from 'react'
+import { useAuth } from './useAuth'
+
+// ユーザー情報の型定義
+interface User {
+  user_id: number
+  user_name: string
+  email: string
+  role: string
+  is_active: boolean
+  account_status: string
+  manager_name?: string
+}
+
+/**
+ * ユーザー情報を取得するカスタムフック
+ * ログインしているユーザーのIDを使用して、最新のユーザー情報をAPIから取得します。
+ */
+export function useUser() {
+  const [userInfo, setUserInfo] = useState<User | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const { user } = useAuth()
+
+  const fetchUser = useCallback(async () => {
+    if (!user?.user_id) return
+
+    try {
+      setLoading(true)
+      setError(null)
+
+      const baseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:7071/api'
+      const response = await fetch(`${baseUrl}/users/${user.user_id}`)
+      
+      if (!response.ok) {
+        throw new Error(`API error: ${response.status}`)
+      }
+
+      const data = await response.json()
+      setUserInfo(data.user)
+    } catch (err) {
+      console.error("Error fetching user info:", err)
+      setError(`Error fetching user info: ${err instanceof Error ? err.message : String(err)}`)
+      // エラー時には認証情報のユーザー名をフォールバックとして使用
+      if (user) {
+        setUserInfo({
+          user_id: user.user_id,
+          user_name: user.user_name,
+          email: user.email,
+          role: user.role || 'member',
+          is_active: true,
+          account_status: 'active'
+        })
+      }
+    } finally {
+      setLoading(false)
+    }
+  }, [user])
+
+  useEffect(() => {
+    if (user?.user_id) {
+      fetchUser()
+    }
+  }, [user, fetchUser])
+
+  return {
+    userInfo,
+    loading,
+    error,
+    refetch: fetchUser
+  }
+} 


### PR DESCRIPTION
1. Usersテーブルから最新のユーザー情報を取得するAPIエンドポイントを追加
- /users/{user_id} エンドポイントの実装
- get_user_by_id 関数の追加
- ルートパラメータの正しい取得方法に修正

2. フロントエンド側での実装
- useUser カスタムフックの作成
- ダッシュボードとマネージャーダッシュボードでの実装

3. デバッグログの削除
- get_members_meetings 関数からデバッグログを削除
- コードの可読性向上

このPRにより、ダッシュボードに常に最新のユーザー情報（user_name）が表示されるようになります。