### PR TITLE
マネージャーダッシュボードにメンバーの会議一覧を表示

### DIFF
--- a/README.md
+++ b/README.md
@@ -701,6 +701,57 @@ Invoke-WebRequest `
   -Headers @{ "Content-Type" = "application/json"; "aeg-event-type" = "Notification" } `
   -Body (Get-Content -Raw -Path "eventgrid-test-payload.json")
 
+## 音声認識・話者分離処理のローカルテストフロー（更新版）
+
+### 🎯 テスト目的
+- `.webm` → `.wav` 変換
+- Azure Speech への transcription job 登録
+- transcription 結果（JSON）を受信
+- 会話セグメント／話者情報を SQL に保存
+
+---
+
+### ✅ STEP 1: `.wav` を削除（再テスト時）
+- ストレージ上の `.wav` を削除（`.webm` は残す）
+
+---
+
+### ✅ STEP 2: Event Grid Trigger を手動発火
+
+```powershell
+# eventgrid-test-payload.json 作成
+$event = @(
+    @{
+        id = [guid]::NewGuid().ToString()
+        subject = "/blobServices/default/containers/moc-audio/blobs/meeting_83_user_34_2025-05-19T07-20-38-755.webm"
+        eventType = "Microsoft.Storage.BlobCreated"
+        eventTime = (Get-Date).ToUniversalTime().ToString("o")
+        dataVersion = "1.0"
+        data = @{
+            api = "PutBlob"
+            clientRequestId = [guid]::NewGuid().ToString()
+            requestId = [guid]::NewGuid().ToString()
+            eTag = "0x8DBB9715E8F04AF"
+            contentType = "video/webm"
+            contentLength = 123456
+            blobType = "BlockBlob"
+            url = "https://audiosalesanalyzeraudio.blob.core.windows.net/moc-audio/meeting_83_user_34_2025-05-19T07-20-38-755.webm"
+            sequencer = "000000000000000000000000000000000000000000000000"
+            storageDiagnostics = @{ batchId = [guid]::NewGuid().ToString() }
+        }
+    }
+) | ConvertTo-Json -Depth 10
+
+$event | Out-File -Encoding UTF8 -FilePath .\eventgrid-test-payload.json
+
+# 発火
+Invoke-WebRequest `
+  -Uri "http://localhost:7072/runtime/webhooks/eventgrid?functionName=TriggerTranscriptionJob" `
+  -Method POST `
+  -Headers @{ "Content-Type" = "application/json"; "aeg-event-type" = "Notification" } `
+  -Body (Get-Content -Raw -Path ".\eventgrid-test-payload.json")
+
+
 
 ## 🔐 Azure Entra ID 認証情報の取得・設定手順
 

--- a/back-end/Table/Tables.sql
+++ b/back-end/Table/Tables.sql
@@ -22,7 +22,7 @@ CREATE TABLE Users (
     password_reset_expires DATETIME NULL,
     login_attempt_count INT DEFAULT 0,
     is_manager BIT NULL,
-    manager_id NVARCHAR NULL
+    manager_id INT NULL
 )
 
 -- 基本情報テーブル

--- a/next-app/src/hooks/useMembersMeetings.tsx
+++ b/next-app/src/hooks/useMembersMeetings.tsx
@@ -33,43 +33,31 @@ export function useMembersMeetings() {
       setError(null)
 
       const baseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:7071/api'
-      const url = `${baseUrl}/members-meetings?account_status=ACTIVE`
+      const url = `${baseUrl}/members-meetings?manager_id=${user.user_id}`
       
+      console.log("🔗 Fetching from:", url)
+      console.log("✅ useMembersMeetings manager_id:", user.user_id)
+
       const response = await fetch(url)
       
       if (!response.ok) {
-        throw new Error(`API error: ${response.status}`)
+        const errorData = await response.json()
+        console.error("❌ API Error Response:", errorData)
+        throw new Error(errorData.error || `API error: ${response.status}`)
       }
 
       const data = await response.json()
+      console.log("📊 Fetched meetings count:", data.length)
       
       // データの存在確認とエラーハンドリング
-      if (!data) {
-        setError("APIからのレスポンスが空です")
-        setMeetings([])
-        return
-      }
-      
-      if (data.error) {
-        setError(`APIエラー: ${data.error}`)
-        setMeetings([])
-        return
-      }
-      
-      if (data.message && !data.meetings) {
-        // エラーではなく情報メッセージとして扱う
-        setMeetings([])
-        return
-      }
-      
-      if (!data.meetings) {
-        setError("APIからのレスポンスに会議データが含まれていません")
+      if (!data || !Array.isArray(data)) {
+        setError("APIからのレスポンスが不正です")
         setMeetings([])
         return
       }
       
       // 日時でソートし、最新10件を取得
-      const sortedMeetings = data.meetings
+      const sortedMeetings = data
         .sort((a: Meeting, b: Meeting) => 
           new Date(b.meeting_datetime).getTime() - new Date(a.meeting_datetime).getTime()
         )


### PR DESCRIPTION
- manager_id をもとにメンバーの会議情報を取得するAPIを実装
- useMembersMeetingsフックに manager_id を渡して商談一覧を取得
- 会議データが正しく取得できない問題をフロント側の構造に合わせて修正
- ログイン中ユーザーの user_id を manager_id として活用