### PR TITLE
マネージャーダッシュボードに会議ごとのコメント一覧を表示

### DIFF
--- a/next-app/src/app/manager-dashboard/page.tsx
+++ b/next-app/src/app/manager-dashboard/page.tsx
@@ -11,39 +11,12 @@ import { useUser } from "@/hooks/useUser"
 import { useMembersMeetings } from "@/hooks/useMembersMeetings"
 import React, { useState, useEffect } from "react"
 import ProtectedRoute from "@/components/auth/ProtectedRoute"
+import { CommentsList } from '@/components/comments/CommentsList'
 
 export default function ManagerDashboard() {
-  // useAuthフックを使用してユーザー情報とログアウト関数を取得
-  const { user, logout } = useAuth();
-  const { userInfo, loading: userLoading } = useUser();
-  const { meetings, loading, error } = useMembersMeetings();
-  
-  const comments = [
-    {
-      id: 1,
-      client: "株式会社ABC",
-      comment: "予算について具体的な話し合いができました。次回は見積書を持参します。",
-      commentTime: "02-07 15:30",
-      salesPerson: "田中 一郎",
-      isRead: false,
-    },
-    {
-      id: 2,
-      client: "DEF工業",
-      comment: "技術的な課題について深い議論ができました。開発チームに確認が必要です。",
-      commentTime: "02-07 13:00",
-      salesPerson: "鈴木 花子",
-      isRead: true,
-    },
-    {
-      id: 3,
-      client: "GHIシステムズ",
-      comment: "導入に前向きな反応でした。来週までに提案書を準備します。",
-      commentTime: "02-06 16:30",
-      salesPerson: "佐藤 健一",
-      isRead: false,
-    },
-  ]
+  const { user, logout } = useAuth()
+  const { userInfo, loading: userLoading } = useUser()
+  const { meetings, loading, error } = useMembersMeetings()
 
   // 日付をフォーマットする関数
   const formatDateTime = (dateTimeStr: string) => {
@@ -67,7 +40,7 @@ export default function ManagerDashboard() {
 
   // ログアウト処理
   const handleLogout = () => {
-    logout();
+    logout()
   }
 
   useEffect(() => {
@@ -75,6 +48,14 @@ export default function ManagerDashboard() {
     console.log('Usersテーブル検索結果:', userInfo)
     console.log('user_name:', userInfo?.user_name ?? user?.user_name)
   }, [user, userInfo])
+
+  if (!user) {
+    return (
+      <div className="p-4 text-center">
+        <p className="text-gray-600">ログインしてください</p>
+      </div>
+    )
+  }
 
   return (
     <ProtectedRoute requireManager={true}>
@@ -179,31 +160,38 @@ export default function ManagerDashboard() {
             </ScrollArea>
           </Card>
 
-          {/* 最新のコメント */}
+          {/* コメント一覧 */}
           <Card className="p-4 sm:p-6">
-            <h2 className="text-lg sm:text-xl font-semibold mb-4">最新のコメント</h2>
+            <h2 className="text-lg sm:text-xl font-semibold mb-4">コメント一覧</h2>
             <ScrollArea className="h-[300px] sm:h-[600px]">
-              <div className="space-y-4">
-                {comments.map((comment) => (
-                  <Link
-                    key={comment.id}
-                    href={`/feedback#${comment.id}`}
-                    className="block border-b last:border-0 pb-4 hover:bg-slate-50 rounded-lg transition-colors"
-                  >
-                    <div className="flex justify-between items-start mb-2">
-                      <div>
-                        <div className="text-sm font-medium">{comment.salesPerson}</div>
-                        <div className="text-sm text-gray-500">{comment.client}</div>
-                      </div>
-                      <div className="flex items-center gap-2">
-                        {!comment.isRead && <Badge variant="destructive">未読</Badge>}
-                        <span className="text-sm text-gray-500">{comment.commentTime}</span>
+              {meetings.map((meeting) => (
+                <div key={meeting.meeting_id} className="mb-4 last:mb-0">
+                  <Link href={`/feedback/${meeting.meeting_id}`} className="block">
+                    <div className="mb-2 pb-2 border-b hover:bg-slate-50 transition-colors p-2 rounded">
+                      <div className="flex justify-between items-start">
+                        <div>
+                          <h3 className="font-medium text-gray-900">
+                            {meeting.title || '無題の会議'}
+                          </h3>
+                          <p className="text-sm text-gray-600">
+                            {meeting.client_company_name && `${meeting.client_company_name} - `}
+                            {meeting.client_contact_name}
+                          </p>
+                          <p className="text-xs text-gray-500">
+                            {new Date(meeting.meeting_datetime).toLocaleString('ja-JP')}
+                          </p>
+                        </div>
+                        <div className="text-sm text-blue-600">
+                          {meeting.user_name}
+                        </div>
                       </div>
                     </div>
-                    <p className="text-sm text-gray-600">{comment.comment}</p>
                   </Link>
-                ))}
-              </div>
+                  <div className="pl-2">
+                    <CommentsList meetingId={meeting.meeting_id} />
+                  </div>
+                </div>
+              ))}
             </ScrollArea>
           </Card>
         </div>

--- a/next-app/src/components/comments/CommentsList.tsx
+++ b/next-app/src/components/comments/CommentsList.tsx
@@ -1,0 +1,77 @@
+"use client"
+
+import { useEffect } from 'react'
+import { useComments } from '@/hooks/useComments'
+import Link from 'next/link'
+
+interface CommentsListProps {
+  meetingId: number
+}
+
+export function CommentsList({ meetingId }: CommentsListProps) {
+  const { comments, loading, error, fetchCommentsByMeetingId } = useComments()
+
+  useEffect(() => {
+    console.log("🧪 Fetching comments for meeting:", meetingId)
+    fetchCommentsByMeetingId(meetingId)
+  }, [meetingId, fetchCommentsByMeetingId])
+
+  useEffect(() => {
+    console.log("🧪 Fetched comments for meeting:", meetingId, comments)
+  }, [comments, meetingId])
+
+  if (loading) {
+    return (
+      <div className="py-2">
+        <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-rose-500 mx-auto"></div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="py-2 text-red-500 text-xs">
+        {error}
+      </div>
+    )
+  }
+
+  if (comments.length === 0) {
+    return (
+      <div className="py-2 text-gray-500 text-xs">
+        コメントはまだありません
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-2">
+      {comments.map((comment) => (
+        <Link
+          key={comment.comment_id}
+          href={`/feedback/${meetingId}#comment-${comment.comment_id}`}
+          className="block hover:bg-slate-50 transition-colors rounded p-2"
+        >
+          <div className="flex items-start justify-between">
+            <div className="flex-1 min-w-0">
+              <p className="text-xs text-gray-600 mb-1">
+                <span className="font-medium text-gray-900">{comment.user_name}</span>
+              </p>
+              <p className="text-gray-800 text-xs whitespace-pre-wrap break-words">
+                {comment.content}
+              </p>
+            </div>
+            <div className="ml-2 text-xs text-gray-500 shrink-0">
+              {new Date(comment.inserted_datetime).toLocaleString('ja-JP', {
+                month: '2-digit',
+                day: '2-digit',
+                hour: '2-digit',
+                minute: '2-digit'
+              })}
+            </div>
+          </div>
+        </Link>
+      ))}
+    </div>
+  )
+} 

--- a/next-app/src/hooks/useComments.tsx
+++ b/next-app/src/hooks/useComments.tsx
@@ -1,0 +1,60 @@
+"use client"
+
+import { useState, useCallback } from 'react'
+
+interface Comment {
+  comment_id: number
+  meeting_id: number
+  user_id: number
+  user_name: string
+  content: string
+  inserted_datetime: string
+  updated_datetime: string | null
+}
+
+export function useComments() {
+  const [comments, setComments] = useState<Comment[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchCommentsByMeetingId = useCallback(async (meetingId: number) => {
+    try {
+      setLoading(true)
+      setError(null)
+
+      const baseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:7071'
+      const url = `${baseUrl}/api/comments/by-meeting/${meetingId}`
+      
+      console.log("🔗 Fetching comments from:", url)
+
+      const response = await fetch(url)
+      
+      if (!response.ok) {
+        const errorData = await response.json()
+        console.error("❌ API Error Response:", errorData)
+        throw new Error(errorData.error || `API error: ${response.status}`)
+      }
+
+      const data = await response.json()
+      console.log("📝 Fetched comments count:", data.length)
+      
+      if (!Array.isArray(data)) {
+        throw new Error("Invalid response format")
+      }
+
+      setComments(data)
+    } catch (err) {
+      setError(`Error fetching comments: ${err instanceof Error ? err.message : String(err)}`)
+      setComments([])
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  return {
+    comments,
+    loading,
+    error,
+    fetchCommentsByMeetingId
+  }
+} 


### PR DESCRIPTION
- CommentsList コンポーネントを会議一覧の右側に追加し、meeting_id に紐づくコメントを表示
- useComments フックを活用し、各会議ごとにコメントを取得
- API エンドポイント `/api/comments/by-meeting/{meeting_id}` を呼び出して最新コメントを取得
- useEffect によるログ追加、状態監視を追加
- コメントがない場合やエラー時もメッセージを表示するように調整