### PR TITLE
fix: 自分のコメントに対する削除ボタンを復活

### DIFF
--- a/next-app/src/app/feedback/[meeting_id]/page.tsx
+++ b/next-app/src/app/feedback/[meeting_id]/page.tsx
@@ -388,6 +388,7 @@ export default function FeedbackPage() {
                                     )
                                   }))
                                 }}
+                                onDeleteComment={(commentId) => handleDeleteComment(commentId, segment.segment_id)}
                               />
                             ) : <div className="text-sm text-gray-500 mb-3">まだコメントはありません</div>}
                             

--- a/next-app/src/components/feedback/comment-list.tsx
+++ b/next-app/src/components/feedback/comment-list.tsx
@@ -4,13 +4,16 @@ import * as React from 'react'
 import { Comment } from '@/types/comment'
 import { ReadButton } from './read-button'
 import { useAuth } from '@/hooks/useAuth'
+import { Trash2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
 
 interface CommentListProps {
   comments: Comment[]
   onCommentRead: (commentId: number) => void
+  onDeleteComment?: (commentId: number) => void
 }
 
-export function CommentList({ comments, onCommentRead }: CommentListProps) {
+export function CommentList({ comments, onCommentRead, onDeleteComment }: CommentListProps) {
   const { user } = useAuth()
   const currentUserId = user?.user_id
 
@@ -25,16 +28,27 @@ export function CommentList({ comments, onCommentRead }: CommentListProps) {
           </div>
           <p className="text-sm">{comment.content}</p>
           
-          {comment.user_id !== currentUserId && (
-            <div className="absolute bottom-2 right-2">
+          <div className="absolute bottom-2 right-2 flex items-center gap-2">
+            {comment.user_id === currentUserId && onDeleteComment && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => onDeleteComment(comment.comment_id)}
+                className="text-xs text-red-500 hover:text-red-600 hover:bg-red-50"
+              >
+                <Trash2 size={14} className="mr-1" />
+                削除
+              </Button>
+            )}
+            {comment.user_id !== currentUserId && (
               <ReadButton
                 commentId={comment.comment_id}
                 userId={currentUserId}
                 isRead={comment.readers.some(reader => reader.reader_id === currentUserId)}
                 onRead={() => onCommentRead(comment.comment_id)}
               />
-            </div>
-          )}
+            )}
+          </div>
         </div>
       ))}
     </div>


### PR DESCRIPTION
フィードバック画面において、自分のコメントに表示されるはずの削除ボタンが意図せず非表示になっていた問題を修正。 条件判定を再確認のうえ、自分のコメントに正しく削除ボタンが表示されるよう復元した。